### PR TITLE
Add fish 🐟  emoji if in allergens

### DIFF
--- a/app/src/main/kotlin/de/janhopp/luebeckmensawidget/api/model/Meal.kt
+++ b/app/src/main/kotlin/de/janhopp/luebeckmensawidget/api/model/Meal.kt
@@ -15,6 +15,7 @@ data class Meal(
     val widgetName = when {
         vegan -> "🌻 "
         vegetarian -> "🌽 "
+        "Fisch" in allergens.map { it.name } -> "🐟 "
         else -> "🥩 "
     }.plus(name)
 }

--- a/app/src/main/kotlin/de/janhopp/luebeckmensawidget/api/model/Meal.kt
+++ b/app/src/main/kotlin/de/janhopp/luebeckmensawidget/api/model/Meal.kt
@@ -15,7 +15,7 @@ data class Meal(
     val widgetName = when {
         vegan -> "🌻 "
         vegetarian -> "🌽 "
-        "Fisch" in allergens.map { it.name } -> "🐟 "
+        "Fi" in allergens.map { it.code } -> "🐟 "
         else -> "🥩 "
     }.plus(name)
 }


### PR DESCRIPTION
fixes #40

This uses `allergens` instead of `name`, what should be more reliable.