### PR TITLE
Make app translatable, translate to German

### DIFF
--- a/app/src/main/kotlin/de/janhopp/luebeckmensawidget/ui/MensaScreen.kt
+++ b/app/src/main/kotlin/de/janhopp/luebeckmensawidget/ui/MensaScreen.kt
@@ -8,12 +8,14 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.res.stringResource
 import androidx.glance.GlanceModifier
 import androidx.glance.LocalContext
 import androidx.glance.background
 import androidx.glance.layout.Alignment
 import androidx.glance.layout.Box
 import androidx.glance.layout.fillMaxSize
+import de.janhopp.luebeckmensawidget.R
 import de.janhopp.luebeckmensawidget.api.model.MensaDay
 import de.janhopp.luebeckmensawidget.storage.OptionsStorage
 import de.janhopp.luebeckmensawidget.widget.MensaWidgetConfig
@@ -48,7 +50,7 @@ fun MensaScreen(
         else if (day != null)
             MensaDayView(day, widgetConfig)
         else
-            ErrorView(errorMessage = "Couldn't load menu...")
+            ErrorView(errorMessage = stringResource(R.string.error_could_not_load_menu))
 
         RefreshButton {
             scope.launch {

--- a/app/src/main/kotlin/de/janhopp/luebeckmensawidget/ui/config/ConfigurationList.kt
+++ b/app/src/main/kotlin/de/janhopp/luebeckmensawidget/ui/config/ConfigurationList.kt
@@ -11,7 +11,9 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import de.janhopp.luebeckmensawidget.R
 import de.janhopp.luebeckmensawidget.api.model.PriceGroup
 import de.janhopp.luebeckmensawidget.storage.Option
 import de.janhopp.luebeckmensawidget.storage.OptionsStorage
@@ -41,7 +43,7 @@ fun ConfigurationList(
             .then(modifier),
     ) {
         OptionSwitch(
-            text = "Show date",
+            text = stringResource(R.string.option_show_date),
             checked = isShowDateEnabled,
             onCheckedChange = {
                 isShowDateEnabled = !isShowDateEnabled
@@ -51,7 +53,7 @@ fun ConfigurationList(
             },
         )
         OptionSwitch(
-            text = "Use emoji in meal names",
+            text = stringResource(R.string.option_use_emoji),
             checked = isUseEmojiEnabled,
             onCheckedChange = {
                 isUseEmojiEnabled = !isUseEmojiEnabled
@@ -61,7 +63,7 @@ fun ConfigurationList(
             },
         )
         OptionDropdownMenu(
-            text = "Price to show",
+            text = stringResource(R.string.option_price_group),
             options = PriceGroup.names,
             onOptionSelected = {
                 priceGroupSelected = it

--- a/app/src/main/kotlin/de/janhopp/luebeckmensawidget/ui/config/ConfigurationList.kt
+++ b/app/src/main/kotlin/de/janhopp/luebeckmensawidget/ui/config/ConfigurationList.kt
@@ -18,6 +18,7 @@ import de.janhopp.luebeckmensawidget.api.model.PriceGroup
 import de.janhopp.luebeckmensawidget.storage.Option
 import de.janhopp.luebeckmensawidget.storage.OptionsStorage
 import de.janhopp.luebeckmensawidget.ui.theme.MensaTheme
+import de.janhopp.luebeckmensawidget.ui.utils.stringRes
 import kotlinx.coroutines.launch
 
 @Composable
@@ -62,16 +63,17 @@ fun ConfigurationList(
                 }
             },
         )
-        OptionDropdownMenu(
+        OptionDropdownMenu<PriceGroup>(
             text = stringResource(R.string.option_price_group),
-            options = PriceGroup.names,
-            onOptionSelected = {
-                priceGroupSelected = it
+            options = PriceGroup.entries,
+            optionToString = { group -> group.stringRes() },
+            onOptionSelected = { group ->
+                priceGroupSelected = group.name
                 coroutineScope.launch {
-                    options.setString(Option.PriceGroup, it)
+                    options.setString(Option.PriceGroup, group.name)
                 }
             },
-            selectedOption = priceGroupSelected,
+            selectedOption = PriceGroup.valueOf(priceGroupSelected),
         )
     }
 }

--- a/app/src/main/kotlin/de/janhopp/luebeckmensawidget/ui/config/OptionDropdownMenu.kt
+++ b/app/src/main/kotlin/de/janhopp/luebeckmensawidget/ui/config/OptionDropdownMenu.kt
@@ -18,11 +18,12 @@ import androidx.compose.ui.Modifier
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun OptionDropdownMenu(
+inline fun <reified T: Enum<T>> OptionDropdownMenu(
     text: String,
-    options: List<String>,
-    selectedOption: String,
-    onOptionSelected: (String) -> Unit,
+    options: List<T>,
+    selectedOption: T,
+    crossinline optionToString: @Composable (T) -> String,
+    crossinline onOptionSelected: (T) -> Unit,
 ) {
     var expanded by remember { mutableStateOf(false) }
 
@@ -40,7 +41,7 @@ fun OptionDropdownMenu(
                             enabled = true,
                         ),
                     readOnly = true,
-                    value = selectedOption,
+                    value = optionToString(selectedOption),
                     onValueChange = {},
                     label = { Text(text) },
                     trailingIcon = { ExposedDropdownMenuDefaults.TrailingIcon(expanded = expanded) },
@@ -52,7 +53,7 @@ fun OptionDropdownMenu(
                 ) {
                     options.forEach { option ->
                         DropdownMenuItem(
-                            text = { Text(option) },
+                            text = { Text(optionToString(option)) },
                             onClick = {
                                 expanded = false
                                 onOptionSelected(option)

--- a/app/src/main/kotlin/de/janhopp/luebeckmensawidget/ui/config/WidgetConfigurationScreen.kt
+++ b/app/src/main/kotlin/de/janhopp/luebeckmensawidget/ui/config/WidgetConfigurationScreen.kt
@@ -12,7 +12,9 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import de.janhopp.luebeckmensawidget.R
 import de.janhopp.luebeckmensawidget.ui.theme.MensaTheme
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -29,14 +31,14 @@ fun WidgetConfigurationScreen(
                     containerColor = MaterialTheme.colorScheme.primaryContainer,
                     titleContentColor = MaterialTheme.colorScheme.primary,
                 ),
-                title = { Text(text = "Settings") },
+                title = { Text(text = stringResource(R.string.widget_settings_title)) },
             )
         },
         floatingActionButton = {
             ExtendedFloatingActionButton(
                 onClick = onConfigurationFinished,
             ) {
-                Text(text = "Finish Configuration")
+                Text(text = stringResource(R.string.finish_configuration))
             }
         }
     ) {

--- a/app/src/main/kotlin/de/janhopp/luebeckmensawidget/ui/utils/Strings.kt
+++ b/app/src/main/kotlin/de/janhopp/luebeckmensawidget/ui/utils/Strings.kt
@@ -1,0 +1,16 @@
+package de.janhopp.luebeckmensawidget.ui.utils
+
+import androidx.compose.ui.res.stringResource
+import androidx.compose.runtime.Composable
+import de.janhopp.luebeckmensawidget.R
+import de.janhopp.luebeckmensawidget.api.model.PriceGroup
+
+@Composable
+fun PriceGroup.stringRes(): String =
+    stringResource(
+        when (this) {
+            PriceGroup.Students -> R.string.price_group_students
+            PriceGroup.Employees -> R.string.price_group_employees
+            PriceGroup.Guests -> R.string.price_group_guests
+        }
+    )

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Lübeck Mensa Widget</string>
+    <string name="widget_settings_title">Einstellungen</string>
+    <string name="finish_configuration">Konfiguration speichern</string>
+    <string name="option_show_date">Datum anzeigen</string>
+    <string name="option_use_emoji">Emoji anzeigen</string>
+    <string name="option_price_group">Preisgruppe</string>
+    <string name="error_could_not_load_menu">Menü konnte nicht geladen werden…</string>
+    <string name="price_group_students">Studierende</string>
+    <string name="price_group_employees">Angestellte</string>
+    <string name="price_group_guests">Gäste</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,12 @@
 <resources>
     <string name="app_name">Lübeck Mensa Widget</string>
+    <string name="widget_settings_title">Settings</string>
+    <string name="finish_configuration">Finish Configuration</string>
+    <string name="option_show_date">Show date</string>
+    <string name="option_use_emoji">Use emoji in meal names</string>
+    <string name="option_price_group">Price to show</string>
+    <string name="error_could_not_load_menu">Couldn\'t load menu…</string>
+    <string name="price_group_students">Students</string>
+    <string name="price_group_employees">Employees</string>
+    <string name="price_group_guests">Guests</string>
 </resources>


### PR DESCRIPTION
fixes #44

This was a bit more involved than expected, but every bit of text should be translatable.

I also added German translations, since this will be the most common language next to English.