### PR TITLE
Allow change of location

### DIFF
--- a/app/src/main/kotlin/de/janhopp/luebeckmensawidget/api/MensaApi.kt
+++ b/app/src/main/kotlin/de/janhopp/luebeckmensawidget/api/MensaApi.kt
@@ -1,7 +1,9 @@
 package de.janhopp.luebeckmensawidget.api
 
+import de.janhopp.luebeckmensawidget.api.model.Location
 import de.janhopp.luebeckmensawidget.api.model.MensaDay
 import de.janhopp.luebeckmensawidget.api.model.toApiResponse
+import de.janhopp.luebeckmensawidget.api.model.toCodes
 import de.janhopp.luebeckmensawidget.api.model.toMensaDays
 import de.janhopp.luebeckmensawidget.utils.alsoThrow
 import de.janhopp.luebeckmensawidget.utils.currentTime
@@ -17,8 +19,8 @@ class MensaApi(
     private val date: String
         get() = currentTime.mensaApiFormat
 
-    suspend fun getMealsToday(): List<MensaDay> = runCatching {
-        client.get("https://speiseplan.mcloud.digital/v2/meals?location=HL_ME&date=$date")
+    suspend fun getMealsToday(locations: Set<Location>): List<MensaDay> = runCatching {
+        client.get("https://speiseplan.mcloud.digital/v2/meals?location=${locations.toCodes()}&date=$date")
             .body<String>()
             .toApiResponse()
             .toMensaDays()

--- a/app/src/main/kotlin/de/janhopp/luebeckmensawidget/api/model/Location.kt
+++ b/app/src/main/kotlin/de/janhopp/luebeckmensawidget/api/model/Location.kt
@@ -1,0 +1,16 @@
+package de.janhopp.luebeckmensawidget.api.model
+
+enum class Location(
+    val code: String,
+) {
+    MensaLuebeck(code = "HL_ME"),
+    CafeteriaLuebeck(code = "HL_CA"),
+    MusikhochschuleLuebeck(code = "HL_MH"),
+    ;
+
+    companion object {
+        fun fromCode(code: String): Location? = entries.find { it.code == code }
+    }
+}
+
+fun Set<Location>.toCodes() = joinToString(separator = ",") { it.code }

--- a/app/src/main/kotlin/de/janhopp/luebeckmensawidget/storage/OptionsStorage.kt
+++ b/app/src/main/kotlin/de/janhopp/luebeckmensawidget/storage/OptionsStorage.kt
@@ -4,8 +4,10 @@ import android.content.Context
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
+import androidx.datastore.preferences.core.stringSetPreferencesKey
 import de.janhopp.luebeckmensawidget.api.model.PriceGroup.Students
 import androidx.datastore.preferences.preferencesDataStore
+import de.janhopp.luebeckmensawidget.api.model.Location
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
 
@@ -34,9 +36,19 @@ class OptionsStorage(
         dataStore.edit { preferences -> preferences[option.toStringKey()] = value }
     }
 
+    suspend fun getStringSet(option: Option<Set<String>>): Set<String> {
+        return dataStore.data.map { preferences -> preferences[option.toStringSetKey()] }.firstOrNull()
+            ?: option.defaultValue
+    }
+
+    suspend fun setStringSet(option: Option<Set<String>>, value: Set<String>) {
+        dataStore.edit { preferences -> preferences[option.toStringSetKey()] = value }
+    }
+
     private companion object {
         fun Option<Boolean>.toBooleanKey() = booleanPreferencesKey(key)
         fun Option<String>.toStringKey() = stringPreferencesKey(key)
+        fun Option<Set<String>>.toStringSetKey() = stringSetPreferencesKey(key)
     }
 }
 
@@ -48,4 +60,5 @@ sealed class Option<T>(
     data object UseEmoji : Option<Boolean>(key = "use_emoji", defaultValue = true)
     data object PriceGroup : Option<String>(key = "price_group", defaultValue = Students.name)
     data object FilterDeals : Option<Boolean>(key = "filter_deals", defaultValue = false)
+    data object Locations : Option<Set<String>>(key = "locations", defaultValue = setOf(Location.MensaLuebeck.code))
 }

--- a/app/src/main/kotlin/de/janhopp/luebeckmensawidget/ui/config/ConfigurationList.kt
+++ b/app/src/main/kotlin/de/janhopp/luebeckmensawidget/ui/config/ConfigurationList.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import de.janhopp.luebeckmensawidget.R
+import de.janhopp.luebeckmensawidget.api.model.Location
 import de.janhopp.luebeckmensawidget.api.model.PriceGroup
 import de.janhopp.luebeckmensawidget.storage.Option
 import de.janhopp.luebeckmensawidget.storage.OptionsStorage
@@ -81,6 +82,18 @@ fun ConfigurationList(
                     options.setBoolean(Option.FilterDeals, it)
                 }
             },
+        )
+        OptionDropdownMenu<Location>(
+            text = stringResource(R.string.option_location),
+            options = Location.entries,
+            optionToString = { location -> location.stringRes() },
+            onOptionSelected = { locations ->
+                widgetConfig = widgetConfig.copy(locations = setOf(locations))
+                coroutineScope.launch {
+                    options.setStringSet(Option.Locations, setOf(locations.code))
+                }
+            },
+            selectedOption = widgetConfig.locations.first(),
         )
     }
 }

--- a/app/src/main/kotlin/de/janhopp/luebeckmensawidget/ui/utils/Strings.kt
+++ b/app/src/main/kotlin/de/janhopp/luebeckmensawidget/ui/utils/Strings.kt
@@ -3,6 +3,7 @@ package de.janhopp.luebeckmensawidget.ui.utils
 import androidx.compose.ui.res.stringResource
 import androidx.compose.runtime.Composable
 import de.janhopp.luebeckmensawidget.R
+import de.janhopp.luebeckmensawidget.api.model.Location
 import de.janhopp.luebeckmensawidget.api.model.PriceGroup
 
 @Composable
@@ -12,5 +13,15 @@ fun PriceGroup.stringRes(): String =
             PriceGroup.Students -> R.string.price_group_students
             PriceGroup.Employees -> R.string.price_group_employees
             PriceGroup.Guests -> R.string.price_group_guests
+        }
+    )
+
+@Composable
+fun Location.stringRes(): String =
+    stringResource(
+        when (this) {
+            Location.MensaLuebeck -> R.string.location_mensa_luebeck
+            Location.CafeteriaLuebeck -> R.string.location_cafeteria_luebeck
+            Location.MusikhochschuleLuebeck -> R.string.location_musikhochschule_luebeck
         }
     )

--- a/app/src/main/kotlin/de/janhopp/luebeckmensawidget/widget/MensaWidget.kt
+++ b/app/src/main/kotlin/de/janhopp/luebeckmensawidget/widget/MensaWidget.kt
@@ -5,7 +5,9 @@ import androidx.glance.GlanceId
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.provideContent
 import de.janhopp.luebeckmensawidget.api.MensaApi
+import de.janhopp.luebeckmensawidget.api.model.Location
 import de.janhopp.luebeckmensawidget.storage.MenuStorage
+import de.janhopp.luebeckmensawidget.storage.OptionsStorage
 import de.janhopp.luebeckmensawidget.theme.AppTheme
 import de.janhopp.luebeckmensawidget.ui.MensaScreen
 import de.janhopp.luebeckmensawidget.utils.currentTime
@@ -20,8 +22,9 @@ class MensaWidget : GlanceAppWidget() {
     override suspend fun provideGlance(context: Context, id: GlanceId) {
         val api = MensaApi()
         val storage = MenuStorage(context)
+        val config = OptionsStorage(context).getWidgetConfig()
         withContext(Dispatchers.IO) {
-            val meals = api.getMealsToday()
+            val meals = api.getMealsToday(config.locations)
 
             val today = if (meals.isEmpty()) {
                 storage.getMensaDay(currentTime.mensaDay).first()

--- a/app/src/main/kotlin/de/janhopp/luebeckmensawidget/widget/MensaWidgetConfig.kt
+++ b/app/src/main/kotlin/de/janhopp/luebeckmensawidget/widget/MensaWidgetConfig.kt
@@ -1,5 +1,6 @@
 package de.janhopp.luebeckmensawidget.widget
 
+import de.janhopp.luebeckmensawidget.api.model.Location
 import de.janhopp.luebeckmensawidget.api.model.PriceGroup
 import de.janhopp.luebeckmensawidget.storage.Option
 import de.janhopp.luebeckmensawidget.storage.OptionsStorage
@@ -9,6 +10,7 @@ data class MensaWidgetConfig(
     val useEmoji: Boolean = Option.UseEmoji.defaultValue,
     val priceGroup: PriceGroup = PriceGroup.valueOf(Option.PriceGroup.defaultValue),
     val filterDeals: Boolean = Option.FilterDeals.defaultValue,
+    val locations: Set<Location> = Option.Locations.defaultValue.mapNotNull { Location.fromCode(it) }.toSet()
 )
 
 suspend fun OptionsStorage.getWidgetConfig() = MensaWidgetConfig(
@@ -16,4 +18,5 @@ suspend fun OptionsStorage.getWidgetConfig() = MensaWidgetConfig(
     getBoolean(Option.UseEmoji),
     PriceGroup.valueOf(getString(Option.PriceGroup)),
     getBoolean(Option.FilterDeals),
+    getStringSet(Option.Locations).mapNotNull { Location.fromCode(it) }.toSet()
 )

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -7,8 +7,12 @@
     <string name="option_use_emoji">Emoji anzeigen</string>
     <string name="option_price_group">Preisgruppe</string>
     <string name="option_filter_deals">Angebote ignorieren</string>
+    <string name="option_location">Standort</string>
     <string name="error_could_not_load_menu">Menü konnte nicht geladen werden…</string>
     <string name="price_group_students">Studierende</string>
     <string name="price_group_employees">Angestellte</string>
     <string name="price_group_guests">Gäste</string>
+    <string name="location_mensa_luebeck">Mensa Lübeck</string>
+    <string name="location_cafeteria_luebeck">Cafeteria Lübeck</string>
+    <string name="location_musikhochschule_luebeck">Musikhochschule Lübeck</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,8 +6,12 @@
     <string name="option_use_emoji">Use emoji in meal names</string>
     <string name="option_price_group">Price to show</string>
     <string name="option_filter_deals">Filter deals</string>
+    <string name="option_location">Location</string>
     <string name="error_could_not_load_menu">Couldn\'t load menu…</string>
     <string name="price_group_students">Students</string>
     <string name="price_group_employees">Employees</string>
     <string name="price_group_guests">Guests</string>
+    <string name="location_mensa_luebeck">Mensa Lübeck</string>
+    <string name="location_cafeteria_luebeck">Cafeteria Lübeck</string>
+    <string name="location_musikhochschule_luebeck">Musikhochschule Lübeck</string>
 </resources>


### PR DESCRIPTION
fixes #55 

This allows the user to change their widget to any of the 3 locations currently available via the API.

Only one location can be selected for now.