### PR TITLE
Fix crash in error/empty case

### DIFF
--- a/app/src/main/kotlin/de/janhopp/luebeckmensawidget/theme/toGlance.kt
+++ b/app/src/main/kotlin/de/janhopp/luebeckmensawidget/theme/toGlance.kt
@@ -1,7 +1,10 @@
 package de.janhopp.luebeckmensawidget.theme
 
+import androidx.annotation.StringRes
+import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.TextUnitType
+import androidx.glance.LocalContext
 import androidx.glance.unit.ColorProvider
 
 fun androidx.compose.ui.text.TextStyle.toGlance(): androidx.glance.text.TextStyle =
@@ -61,3 +64,7 @@ fun androidx.compose.ui.text.font.FontFamily.toGlance(): androidx.glance.text.Fo
     }
 
 fun TextUnit.toGlance(): TextUnit = TextUnit(value, TextUnitType.Sp)
+
+@Composable
+fun glanceString(@StringRes resId: Int, vararg formatArgs: Any): String =
+    LocalContext.current.getString(resId, *formatArgs)

--- a/app/src/main/kotlin/de/janhopp/luebeckmensawidget/ui/MensaScreen.kt
+++ b/app/src/main/kotlin/de/janhopp/luebeckmensawidget/ui/MensaScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.res.stringResource
 import androidx.glance.GlanceModifier
 import androidx.glance.LocalContext
 import androidx.glance.background
@@ -18,6 +17,7 @@ import androidx.glance.layout.fillMaxSize
 import de.janhopp.luebeckmensawidget.R
 import de.janhopp.luebeckmensawidget.api.model.MensaDay
 import de.janhopp.luebeckmensawidget.storage.OptionsStorage
+import de.janhopp.luebeckmensawidget.theme.glanceString
 import de.janhopp.luebeckmensawidget.widget.MensaWidgetConfig
 import de.janhopp.luebeckmensawidget.widget.getWidgetConfig
 import kotlinx.coroutines.delay
@@ -50,7 +50,7 @@ fun MensaScreen(
         else if (day != null)
             MensaDayView(day, widgetConfig)
         else
-            ErrorView(errorMessage = stringResource(R.string.error_could_not_load_menu))
+            ErrorView(errorMessage = glanceString(R.string.error_could_not_load_menu))
 
         RefreshButton {
             scope.launch {


### PR DESCRIPTION
fixes #60

This uses the archaic Android API to avoid a crash caused by using the compose API unavailable to glance widgets.