### PR TITLE
Add work manager

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -84,4 +84,6 @@ dependencies {
     debugImplementation(libs.androidx.ui.tooling)
 
     implementation(libs.androidx.datastore.preferences)
+
+    implementation(libs.androidx.work.runtime.ktx)
 }

--- a/app/src/main/kotlin/de/janhopp/luebeckmensawidget/SyncWorker.kt
+++ b/app/src/main/kotlin/de/janhopp/luebeckmensawidget/SyncWorker.kt
@@ -1,0 +1,14 @@
+package de.janhopp.luebeckmensawidget
+
+import android.content.Context
+import android.util.Log
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+
+class SyncWorker(appContext: Context, workerParams: WorkerParameters) :
+    Worker(appContext, workerParams) {
+    override fun doWork(): Result {
+        Log.d("SyncWorker", "doWork")
+        return Result.success()
+    }
+}

--- a/app/src/main/kotlin/de/janhopp/luebeckmensawidget/SyncWorker.kt
+++ b/app/src/main/kotlin/de/janhopp/luebeckmensawidget/SyncWorker.kt
@@ -2,8 +2,18 @@ package de.janhopp.luebeckmensawidget
 
 import android.content.Context
 import android.util.Log
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.PeriodicWorkRequest
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
 import androidx.work.Worker
 import androidx.work.WorkerParameters
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.toJavaDuration
 
 class SyncWorker(appContext: Context, workerParams: WorkerParameters) :
     Worker(appContext, workerParams) {
@@ -11,4 +21,30 @@ class SyncWorker(appContext: Context, workerParams: WorkerParameters) :
         Log.d("SyncWorker", "doWork")
         return Result.success()
     }
+
+    companion object {
+        val syncWorkRequest: PeriodicWorkRequest =
+            PeriodicWorkRequestBuilder<SyncWorker>(repeatInterval = 1.hours.toJavaDuration())
+                .setConstraints(
+                    buildConstraints {
+                        setRequiredNetworkType(NetworkType.CONNECTED)
+                        setRequiresBatteryNotLow(true)
+                    }
+                )
+                .setBackoffCriteria(BackoffPolicy.LINEAR, duration = 30.minutes.toJavaDuration())
+                .build()
+
+        fun Context.enqueueSyncWork() {
+            Log.d("SyncWorker", "enqueueSyncWork")
+            WorkManager.getInstance(applicationContext)
+                .enqueueUniquePeriodicWork(
+                    SyncWorker::class.java.name,
+                    ExistingPeriodicWorkPolicy.UPDATE,
+                    syncWorkRequest.also { Log.d("SyncWorker", "enqueueSyncWork: $it") }
+                )
+        }
+    }
 }
+
+private fun buildConstraints(builder: Constraints.Builder.() -> Unit): Constraints =
+    Constraints.Builder().apply(builder).build()

--- a/app/src/main/kotlin/de/janhopp/luebeckmensawidget/ui/activity/MensaDayActivity.kt
+++ b/app/src/main/kotlin/de/janhopp/luebeckmensawidget/ui/activity/MensaDayActivity.kt
@@ -4,11 +4,13 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import de.janhopp.luebeckmensawidget.SyncWorker.Companion.enqueueSyncWork
 import de.janhopp.luebeckmensawidget.ui.theme.MensaTheme
 
 class MensaDayActivity: ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        applicationContext.enqueueSyncWork()
         enableEdgeToEdge()
         setContent {
             MensaTheme {

--- a/app/src/main/kotlin/de/janhopp/luebeckmensawidget/widget/MensaWidget.kt
+++ b/app/src/main/kotlin/de/janhopp/luebeckmensawidget/widget/MensaWidget.kt
@@ -11,6 +11,7 @@ import androidx.glance.GlanceId
 import androidx.glance.appwidget.GlanceAppWidget
 import androidx.glance.appwidget.provideContent
 import androidx.glance.appwidget.updateAll
+import de.janhopp.luebeckmensawidget.SyncWorker.Companion.enqueueSyncWork
 import de.janhopp.luebeckmensawidget.api.MensaApi
 import de.janhopp.luebeckmensawidget.api.model.MensaDay
 import de.janhopp.luebeckmensawidget.storage.MenuStorage
@@ -26,6 +27,7 @@ class MensaWidget : GlanceAppWidget() {
     override suspend fun provideGlance(context: Context, id: GlanceId) {
         val api = MensaApi()
         val storage = MenuStorage(context)
+        context.enqueueSyncWork()
 
         provideContent {
             var config by remember { mutableStateOf<MensaWidgetConfig?>(null) }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ ktx = "1.17.0"
 material = "1.12.0"
 material3 = "1.3.2"
 navigation = "2.9.3"
+workRuntimeKtx = "2.10.3"
 
 [libraries]
 androidx-activity-compose = { module = "androidx.activity:activity-compose" }
@@ -31,6 +32,7 @@ androidx-navigation-compose = { module = "androidx.navigation:navigation-compose
 androidx-ui = { module = "androidx.compose.ui:ui" }
 androidx-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 androidx-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview" }
+androidx-work-runtime-ktx = { module = "androidx.work:work-runtime-ktx", version.ref = "workRuntimeKtx" }
 junit = { module = "junit:junit", version.ref = "junit" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect" }
 kotlinx-datetime = { module = "org.jetbrains.kotlinx:kotlinx-datetime", version.ref = "kotlinxDatetime" }


### PR DESCRIPTION
resolves #46
fixes #92

Gets the current day's meals and saves them locally for the actvity and widget to use on recomposition.

Needs testing on Samsung...