### PR TITLE
Remove non-user-initiated networking in widget

### DIFF
--- a/app/src/main/kotlin/de/janhopp/luebeckmensawidget/widget/MensaWidget.kt
+++ b/app/src/main/kotlin/de/janhopp/luebeckmensawidget/widget/MensaWidget.kt
@@ -41,7 +41,9 @@ class MensaWidget : GlanceAppWidget() {
                 todayFromStorage = storage.getMensaDay(currentTime.mensaDay).firstOrNull()
             }
             LaunchedEffect(Unit) {
-                updateConfigAndMenu()
+                // NOTE: updating from storage only!
+                //  it seems networking is only allowed on user interaction, at least for Samsung...
+                todayFromStorage = storage.getMensaDay(currentTime.mensaDay).firstOrNull()
             }
             val scope = rememberCoroutineScope()
             val update: () -> Unit = {


### PR DESCRIPTION
- intended to make samsung devices update widget at all
- this might make the UX worse for everybody

refs #92 